### PR TITLE
Rgmelins timeout bugfix

### DIFF
--- a/cooper_pair/pair.py
+++ b/cooper_pair/pair.py
@@ -218,6 +218,8 @@ class CooperPair(object):
         try:
             return self.client.execute(query_gql, variable_values=variables)
         except (requests.exceptions.HTTPError, RetryError):
+            self.transport.headers = dict(
+                self.transport.headers or {}, **{'X-Fullerene-Token': None})
             self._client = None
             return self.client.execute(query_gql, variable_values=variables)
 


### PR DESCRIPTION
If query fails due to RetryError, clear token from transport headers, then re-login to refresh authToken.