### PR TITLE
Return expectation_ids; assign expectation ids

### DIFF
--- a/cooper_pair/pair.py
+++ b/cooper_pair/pair.py
@@ -200,7 +200,7 @@ class CooperPair(object):
         return [
             {
                 'success': result['success'],
-            
+                'expectationId': result['expectation_id'],
                 'expectationType': result['expectation_config']['expectation_type'],
                 'expectationKwargs': json.dumps(result['expectation_config']['kwargs']),
             
@@ -452,6 +452,10 @@ class CooperPair(object):
             result_format="SUMMARY",
             catch_exceptions=True)
         results = ge_results['results']
+        
+        for idx, expectation_id in enumerate(expectations_config['expectation_ids']):
+            results[idx]['expectation_id'] = expectation_id
+        
         munged_results = self.munge_ge_evaluation_results(ge_results=results)
         new_dataset = self.add_dataset(project_id=1, label=dataset_label)
         new_dataset_id = new_dataset['addDataset']['dataset']['id']
@@ -1560,8 +1564,10 @@ class CooperPair(object):
                 for expectation
                 in checkpoint['checkpoint']['expectationSuite']['expectations']['edges']
                 if expectation['node']['isActivated']]
+        expectation_ids = [expectation['id'] for expectation in expectations]
         expectations_config = {
             'meta': {'great_expectations.__version__': '0.4.4'},
+            'expectation_ids': expectation_ids,
             'dataset_name': None,
             'expectations': [
                 {'expectation_type': expectation['expectationType'],

--- a/cooper_pair/pair.py
+++ b/cooper_pair/pair.py
@@ -447,13 +447,15 @@ class CooperPair(object):
             checkpoint_id = self.get_checkpoint_by_name(checkpoint_name)['checkpoint']['id']
         expectations_config = self.get_checkpoint_as_expectations_config(
             checkpoint_id=checkpoint_id, checkpoint_name=checkpoint_name)
+        expectation_ids = expectations_config.pop('expectation_ids', [])
+        
         ge_results = pandas_df.validate(
             expectations_config=expectations_config,
             result_format="SUMMARY",
             catch_exceptions=True)
         results = ge_results['results']
         
-        for idx, expectation_id in enumerate(expectations_config['expectation_ids']):
+        for idx, expectation_id in enumerate(expectation_ids):
             results[idx]['expectation_id'] = expectation_id
         
         munged_results = self.munge_ge_evaluation_results(ge_results=results)


### PR DESCRIPTION
This PR modifies get_checkpoint_as_expectations_config by adding a new key with expectation ids to the returned expectations config. munge_ge_evaluation_results and evaluate_pandas_df_against_checkpoint are likewise modified to assign expectation_id to results objects.